### PR TITLE
Fixed outdated code related to Twitter OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ The <code>oauth2.Client</code> is based on <code>httplib2</code> and works just 
         secret="your-twitter-consumer-secret")
     
     # Request token URL for Twitter.
-    request_token_url = "http://twitter.com/oauth/request_token"
+    request_token_url = "https://twitter.com/oauth/request_token"
     
     # Create our client.
     client = oauth.Client(consumer)
     
     # The OAuth Client request works just like httplib2 for the most part.
-    resp, content = client.request(request_token_url, "GET")
+    resp, content = client.request(request_token_url, "POST")
     print resp
     print content
 
@@ -77,9 +77,9 @@ can be easily translated to a web application.
     consumer_key = 'my_key_from_twitter'
     consumer_secret = 'my_secret_from_twitter'
     
-    request_token_url = 'http://twitter.com/oauth/request_token'
-    access_token_url = 'http://twitter.com/oauth/access_token'
-    authorize_url = 'http://twitter.com/oauth/authorize'
+    request_token_url = 'https://twitter.com/oauth/request_token'
+    access_token_url = 'https://twitter.com/oauth/access_token'
+    authorize_url = 'https://twitter.com/oauth/authorize'
     
     consumer = oauth.Consumer(consumer_key, consumer_secret)
     client = oauth.Client(consumer)
@@ -88,7 +88,7 @@ can be easily translated to a web application.
     # having the user authorize an access token and to sign the request to obtain 
     # said access token.
     
-    resp, content = client.request(request_token_url, "GET")
+    resp, content = client.request(request_token_url, "POST")
     if resp['status'] != '200':
         raise Exception("Invalid response %s." % resp['status'])
     
@@ -209,15 +209,15 @@ and code here might need to be updated if you are using Python 2.6+.
     consumer = oauth.Consumer(settings.TWITTER_TOKEN, settings.TWITTER_SECRET)
     client = oauth.Client(consumer)
 
-    request_token_url = 'http://twitter.com/oauth/request_token'
-    access_token_url = 'http://twitter.com/oauth/access_token'
+    request_token_url = 'https://twitter.com/oauth/request_token'
+    access_token_url = 'https://twitter.com/oauth/access_token'
 
     # This is the slightly different URL used to authenticate/authorize.
     authenticate_url = 'http://twitter.com/oauth/authenticate'
 
     def twitter_login(request):
         # Step 1. Get a request token from Twitter.
-        resp, content = client.request(request_token_url, "GET")
+        resp, content = client.request(request_token_url, "POST")
         if resp['status'] != '200':
             raise Exception("Invalid response from Twitter.")
 
@@ -245,7 +245,7 @@ and code here might need to be updated if you are using Python 2.6+.
         client = oauth.Client(consumer, token)
     
         # Step 2. Request the authorized access token from Twitter.
-        resp, content = client.request(access_token_url, "GET")
+        resp, content = client.request(access_token_url, "POST")
         if resp['status'] != '200':
             print content
             raise Exception("Invalid response from Twitter.")


### PR DESCRIPTION
All Twitter OAuth urls now use POST and HTTPS (except the user authorize endpoint)
